### PR TITLE
Readme: replace deprecated ioutil usage in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ func main() {
 	arg1 := os.Args[1]
 	arg2 := os.Args[2]
 
-	b, err := ioutil.ReadFile(arg2)
+	b, err := os.ReadFile(arg2)
 	if err != nil {
 		fmt.Print(err)
 		return


### PR DESCRIPTION
Very user friendly that the readme has an example to copy, but it should be updated slightly to avoid getting linter warning about `ioutil` being deprecated.

From ioutil.ReadFile documentation:
> Deprecated: As of Go 1.16, this function simply calls os.ReadFile. 